### PR TITLE
TSP-LION2015-ALGO fix

### DIFF
--- a/TSP-LION2015-ALGO/description.txt
+++ b/TSP-LION2015-ALGO/description.txt
@@ -228,6 +228,8 @@ metainfo_algorithms:
 number_of_feature_steps: 6
 default_steps: 
      - ubc_cheap
+     - code
+     - AST
 feature_steps:
     ubc_cheap:
         provides: 


### PR DESCRIPTION
TSP-LION2015-ALGO was missing 'code' and 'AST' steps in default_steps field in description.txt. I added it.